### PR TITLE
Use flathub for stable linux version.

### DIFF
--- a/static/bits/downloads.js
+++ b/static/bits/downloads.js
@@ -80,9 +80,7 @@
 		if (/ip[ao]d/i.test(ua)) platform = "ios";
 		if (/iphone/i.test(ua))  platform = "ios";
 		if (/android/i.test(ua)) platform = "android";
-		// Fallback to src until our Linux package list becomes more accessible
-		// for casual/new Linux users.
-		//if (/linux/i.test(ua))   platform = "linux";
+		if (/linux/i.test(ua))   platform = "linux";
 
 		if (!(platform in defBranch.files)) {
 			platform = "src";

--- a/static/docroot/index.php
+++ b/static/docroot/index.php
@@ -104,7 +104,7 @@ $branches = [
 			],
 			[
 				'os'    => 'linux',
-				'url'   => 'https://wiki.wesnoth.org/WesnothBinariesLinux',
+				'url'   => 'https://flathub.org/apps/details/org.wesnoth.Wesnoth',
 			],
 			[
 				'os'    => 'ios',


### PR DESCRIPTION
---

Assuming I'm understanding this correctly, this will also have the side effect of making the Linux download button for the stable branch that's in the "Other versions and platforms" section also point to flathub.