### PR TITLE
Use sticky positioning for better navigation in u.w.o

### DIFF
--- a/wesmere/sass/wmlunits/_common.scss
+++ b/wesmere/sass/wmlunits/_common.scss
@@ -72,7 +72,9 @@ div.navbar {
 		flex: 0 0 auto;
 
 		@include media-tiny-screen-constraint {
-			order: 1;
+			order: 0;
+			position: sticky;
+			top: 0;
 		}
 	}
 
@@ -82,12 +84,14 @@ div.navbar {
 		border-left: none;
 
 		@include media-tiny-screen-constraint {
-			order: 0;
+			order: 1;
 		}
 	}
 }
 
 ul.navbar {
+	position: sticky;
+	top: 0;
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -166,6 +170,10 @@ ul.navbar {
 
 		&.overviewlink {
 			margin-top: 2em;
+
+			@include media-tiny-screen-constraint {
+				display: none;
+			}
 		}
 	}
 }

--- a/wesmere/sass/wmlunits/_unit_tree.scss
+++ b/wesmere/sass/wmlunits/_unit_tree.scss
@@ -45,6 +45,9 @@ td.empty {
 }
 
 .raceheader {
+	position: sticky;
+	top: 0;
+
 	font-size: 1.25em;
 	font-weight: bold;
 	text-align: center;


### PR DESCRIPTION
- Side navbar buttons no longer disappear upwards when scrolling down.
- Faction headers stick to the top, providing better context.
- In tiny screens, the navbar sticks to the top rather than being unreachable in the bottom.
- In tiny screens, the link to /overview.html is hidden. Users are encouraged to use the Back button on their phones instead.