### PR TITLE
index.wml: fix typo (`>`)

### DIFF
--- a/static/docroot/addons/index.xml
+++ b/static/docroot/addons/index.xml
@@ -26,7 +26,7 @@
 		<h2>Retired instances</h2>
 
 		<ul>
-			<li><a href="1.17/">Development 1.17></a> <span>(1.17.0&ndash;1.17.x)</span></li>
+			<li><a href="1.17/">Development 1.17</a> <span>(1.17.0&ndash;1.17.x)</span></li>
 			<li><a href="1.15/">Development 1.15</a> <span>(1.15.0&ndash;1.15.13)</span></li>
 			<li><a href="1.13/">Development 1.13</a> <span>(1.13.0&ndash;1.13.11)</span></li>
 			<li><a href="1.12/">Old stable 1.12</a> <span>(1.11.10&ndash;1.12.x)</span></li>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dcbe4aef-c11b-4c11-ad85-f25ff7d5a999)
The extra `>` next to the 1.17 seems to be a typo.